### PR TITLE
Added filters to modify the HTML output & Added option in the plugin settings page to Disable email notification on comment approval

### DIFF
--- a/classes/CommentReplyEmailNotification.php
+++ b/classes/CommentReplyEmailNotification.php
@@ -152,6 +152,10 @@ class CommentReplyEmailNotification
                         <td><input type="checkbox" name="cren_settings[cren_display_gdpr_notice]" value="1" <?php if($this->getDisplayGdprNotice()) echo ' checked="checked"'; ?>/></td>
                     </tr>
                     <tr>
+                        <th scope="row"><?php echo __('Send email notification when comment is approved', 'comment-reply-email-notification'); ?></th>
+                        <td><input type="checkbox" name="cren_settings[cren_send_email_on_comment_approval]" value="1" <?php if($this->getSendEmailOnCommentApprovalChecked()) echo ' checked="checked"'; ?>/></td>
+                    </tr>
+                    <tr>
                         <th scope="row"><?php echo __('Privacy Policy URL', 'comment-reply-email-notification'); ?></th>
                         <td><input type="text" class="regular-text" name="cren_settings[cren_privacy_policy_url]" value="<?php echo htmlspecialchars($this->getSetting('cren_privacy_policy_url', '')); ?>"></td>
                     </tr>
@@ -339,9 +343,7 @@ class CommentReplyEmailNotification
      */
     function commentStatusUpdate($commentId, $commentStatus)
     {
-        $disableEmailNotificationOnCommentApproval = apply_filters( 'cren_disable_email_notification_on_comment_approval', false );
-
-        if( !$disableEmailNotificationOnCommentApproval ) {
+        if( $this->getSendEmailOnCommentApprovalChecked() ) {
             $comment = get_comment($commentId);
 
             if ($commentStatus == 'approve') {
@@ -438,6 +440,16 @@ class CommentReplyEmailNotification
     function getDisplayGdprNotice()
     {
         return $this->getSetting('cren_display_gdpr_notice', false);
+    }
+
+    /**
+     * Return whether email should be send on comment approval.
+     * 
+     * @return bool
+     */
+    function getSendEmailOnCommentApprovalChecked()
+    {
+        return $this->getSetting('cren_send_email_on_comment_approval', false);
     }
 
     /**

--- a/classes/CommentReplyEmailNotification.php
+++ b/classes/CommentReplyEmailNotification.php
@@ -339,10 +339,14 @@ class CommentReplyEmailNotification
      */
     function commentStatusUpdate($commentId, $commentStatus)
     {
-        $comment = get_comment($commentId);
+        $disableEmailNotificationOnCommentApproval = apply_filters( 'cren_disable_email_notification_on_comment_approval', false );
 
-        if ($commentStatus == 'approve') {
-            $this->commentNotification($comment->comment_ID, $comment);
+        if( !$disableEmailNotificationOnCommentApproval ) {
+            $comment = get_comment($commentId);
+
+            if ($commentStatus == 'approve') {
+                $this->commentNotification($comment->comment_ID, $comment);
+            }
         }
     }
 
@@ -358,8 +362,9 @@ class CommentReplyEmailNotification
         $label = apply_filters('cren_comment_checkbox_label', __('Notify me via e-mail if anyone answers my comment.' , 'comment-reply-email-notification'));
         $checked = $this->getDefaultChecked() ? 'checked' : '';
 
-        $fields['cren_subscribe_to_comment'] = '<p class="comment-form-comment-subscribe">'.
-            '<label for="cren_subscribe_to_comment"><input id="cren_subscribe_to_comment" name="cren_subscribe_to_comment" type="checkbox" value="on" ' . $checked . '>' . $label . '</label></p>';
+        $subscribeToCommentsHtml = '<p class="comment-form-comment-subscribe"><label for="cren_subscribe_to_comment"><input id="cren_subscribe_to_comment" name="cren_subscribe_to_comment" type="checkbox" value="on" ' . $checked . '>' . $label . '</label></p>';
+
+        $fields['cren_subscribe_to_comment'] = apply_filters( 'cren_comment_subscribe_html', $subscribeToCommentsHtml, $label, $this->getDefaultChecked() );
 
         if ($this->getDisplayGdprNotice()) {
             $fields['cren_gdpr'] = $this->renderGdprNotice();
@@ -385,7 +390,9 @@ class CommentReplyEmailNotification
             $label   = apply_filters('cren_comment_checkbox_label', __('Notify me via e-mail if anyone answers my comment.' , 'comment-reply-email-notification'));
             $checked = $this->getDefaultChecked() ? 'checked' : '';
 
-            $checkbox = '<p class="comment-form-comment-subscribe"><label for="cren_subscribe_to_comment"><input id="cren_subscribe_to_comment" name="cren_subscribe_to_comment" type="checkbox" value="on"  ' . $checked . '>' . $label . '</label></p>';
+            $subscribeToCommentsHtml = '<p class="comment-form-comment-subscribe"><label for="cren_subscribe_to_comment"><input id="cren_subscribe_to_comment" name="cren_subscribe_to_comment" type="checkbox" value="on" ' . $checked . '>' . $label . '</label></p>';
+
+            $checkbox = apply_filters( 'cren_comment_subscribe_html', $subscribeToCommentsHtml, $label, $this->getDefaultChecked() );
 
             if ($this->getDisplayGdprNotice()) {
                 $checkbox .= $this->renderGdprNotice();
@@ -458,7 +465,14 @@ class CommentReplyEmailNotification
         $privacyPolicyUrl = $this->getPrivacyPolicyUrl();
         $privacyPolicy    = "<a target='_blank' href='{$privacyPolicyUrl}'>(" . __('Privacy Policy', 'comment-reply-email-notification') . ")</a>";
 
-        return '<p class="comment-form-comment-subscribe"><label for="cren_gdpr"><input id="cren_gdpr" name="cren_gdpr" type="checkbox" value="yes" required="required">' . $label . ' ' . $privacyPolicy . ' <span class="required">*</span></label></p>';
+        $finalGdprHtml = '<p class="comment-form-comment-subscribe"><label for="cren_gdpr"><input id="cren_gdpr" name="cren_gdpr" type="checkbox" value="yes" required="required">' . $label . ' ' . $privacyPolicy . ' <span class="required">*</span></label></p>';
+
+        return apply_filters(
+            'cren_gdpr_checkbox_html',
+            $finalGdprHtml,
+            $label,
+            $privacyPolicyUrl
+        );
     }
 
     /**


### PR DESCRIPTION
Hi @arnowelzel & @guhemama,
I've added the following **filters** to the code:
- cren_gdpr_checkbox_html
- cren_comment_subscribe_html

The first two filters allow users to modify the HTML output of the checkbox. This is very important on custom-developed sites which are built using some sort of design framework e.g. Bootstrap.

So, in situations like these instead of adding more HTML to tackle the design issue (which will cause a lot of work and still might not look perfect) - instead, they can just take advantage of the filters to modify the output HTML to ensure it has the native class names that it needs to look perfect.

## Example usage of the filter `cren_gdpr_checkbox_html`

```php
add_filter( 'cren_gdpr_checkbox_html', function( string $html_output, string $label_text, string $privacy_policy_url ) : string {
  $html_output = '<div class="comment-form-gdpr-consent form-check mb-3"><input id="cren_gdpr" class="form-check-input" name="cren_gdpr" type="checkbox" value="yes" required checked><label for="cren_gdpr" class="form-check-label">' . $label_text . '<span class="text-danger fw-bold">*</span> (<a href="' . $privacy_policy_url . '" title="Privacy Policy" target="_blank" rel="internal">Privacy Policy</a>)</label></div>';

  return $html_output;
}, 10, 3 );
```

## Example usage of the filter `cren_comment_subscribe_html`

```php
add_filter( 'cren_comment_subscribe_html', function( string $html_output, string $label_text, bool $checked_default ) : string {
  $checked = $checked_default ? 'checked' : '';

  $html_output = '<div class="comment-form-email-consent form-check mb-3"><input id="cren_subscribe_to_comment" class="form-check-input" name="cren_subscribe_to_comment" type="checkbox" value="on" ' . $checked . '><label for="cren_subscribe_to_comment" class="form-check-label">' . $label_text . '</label></div>';

  return $html_output;
}, 10, 3 );
```
-------------------------------

I've also added an option on the plugin settings page to enable/disable sending email notifications on comment approval. With a single click, users can choose to enable/disable this option.

![screenshot of this new option](https://i.imgur.com/bZTRMoK.jpeg)

I truly hope you merge this PR to your amazing plugin and give your plugin the missing features that are needed to be used in a proper custom developed website. Hope this helps. :)

P.S.: I've already tested the changed code and used these changes on my client sites. But hopefully, once you merge this to the main branch - others will also be able to use them.